### PR TITLE
build: Normalize version

### DIFF
--- a/sdk/openai/azure-ai-openai/pom.xml
+++ b/sdk/openai/azure-ai-openai/pom.xml
@@ -15,7 +15,7 @@
   <groupId>com.azure</groupId>
   <artifactId>azure-ai-openai</artifactId>
   <!-- modified according to the instructions in EVERLAW-README.md -->
-  <version>1.0.0-everlaw.1</version> <!-- {x-version-update;com.azure:azure-ai-openai;current} -->
+  <version>1.0.0-everlaw1</version> <!-- {x-version-update;com.azure:azure-ai-openai;current} -->
   <packaging>jar</packaging>
 
   <name>Microsoft Azure Client Library For OpenAI</name>


### PR DESCRIPTION
Our other forks use an `A.B.C-everlawD` naming convention, so we should too :^)